### PR TITLE
Configure Fly registry properly across all workflows and Dockerfiles

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -17,7 +17,6 @@ permissions:
   id-token: write
 
 env:
-  REGISTRY: odsifra.jfrog.io
   IMAGE_NAME: docker/od-sifra-backend
 
 jobs:
@@ -59,11 +58,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup JFrog Fly
-        id: fly-setup
         uses: jfrog/fly-action@v1
-        with:
-          url: https://odsifra.jfrog.io
-        continue-on-error: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -72,29 +67,19 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.FLY_REGISTRY_SUBDOMAIN }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build Docker image (no push - auth failed)
-        if: steps.fly-setup.outcome != 'success'
-        uses: docker/build-push-action@v5
-        with:
-          context: ./backend
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
       - name: Build and Push Docker image
-        if: steps.fly-setup.outcome == 'success'
         uses: docker/build-push-action@v5
         with:
           context: ./backend
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            FLY_REGISTRY=${{ env.FLY_REGISTRY_SUBDOMAIN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -11,6 +11,10 @@ on:
     paths:
       - 'mobile/**'
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   lint-and-typecheck:
     runs-on: ubuntu-latest
@@ -25,6 +29,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - name: Setup JFrog Fly
+        uses: jfrog/fly-action@v1
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -17,7 +17,6 @@ permissions:
   id-token: write
 
 env:
-  REGISTRY: odsifra.jfrog.io
   IMAGE_NAME: docker/od-sifra-web
 
 jobs:
@@ -61,11 +60,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup JFrog Fly
-        id: fly-setup
         uses: jfrog/fly-action@v1
-        with:
-          url: https://odsifra.jfrog.io
-        continue-on-error: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -74,33 +69,20 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.FLY_REGISTRY_SUBDOMAIN }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build Docker image (no push - auth failed)
-        if: steps.fly-setup.outcome != 'success'
-        uses: docker/build-push-action@v5
-        with:
-          context: ./web
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            NEXT_PUBLIC_API_URL=${{ vars.API_URL || 'https://od-sifra-backend-production.up.railway.app/api' }}
-
       - name: Build and Push Docker image
-        if: steps.fly-setup.outcome == 'success'
         uses: docker/build-push-action@v5
         with:
           context: ./web
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            FLY_REGISTRY=${{ env.FLY_REGISTRY_SUBDOMAIN }}
+            NEXT_PUBLIC_API_URL=${{ vars.API_URL || 'https://od-sifra-backend-production.up.railway.app/api' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            NEXT_PUBLIC_API_URL=${{ vars.API_URL || 'https://od-sifra-backend-production.up.railway.app/api' }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,6 @@
 # Build stage
-FROM node:20-alpine AS builder
+ARG FLY_REGISTRY
+FROM ${FLY_REGISTRY}/docker/node:20-alpine AS builder
 
 WORKDIR /app
 
@@ -23,7 +24,8 @@ RUN npm run build
 # RUN npm prune --omit=dev
 
 # Production stage
-FROM node:20-alpine AS production
+ARG FLY_REGISTRY
+FROM ${FLY_REGISTRY}/docker/node:20-alpine AS production
 
 WORKDIR /app
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,6 @@
 # Build stage
-FROM node:20-alpine AS builder
+ARG FLY_REGISTRY
+FROM ${FLY_REGISTRY}/docker/node:20-alpine AS builder
 
 WORKDIR /app
 
@@ -24,7 +25,8 @@ RUN npm run build
 RUN npm prune --omit=dev
 
 # Production stage
-FROM node:20-alpine AS production
+ARG FLY_REGISTRY
+FROM ${FLY_REGISTRY}/docker/node:20-alpine AS production
 
 WORKDIR /app
 


### PR DESCRIPTION
- Remove continue-on-error workaround from backend/web CI — auth now relies on OIDC via fly-action
- Remove hardcoded registry URL and fallback no-push build steps
- Switch to FLY_REGISTRY_SUBDOMAIN env var exported by fly-action for image names
- Add ARG FLY_REGISTRY to Dockerfiles and pass it via build-args in CI
- Remove invalid url: param from fly-action in mobile-ci.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to streamline Docker registry configuration, removing hardcoded values in favor of environment-based parameters
  * Enhanced GitHub Actions permissions with explicit read access and token write capabilities
  * Optimized Docker build setup across services to support configurable registry sources
  * Simplified CI/CD build and push logic by consolidating conditional steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->